### PR TITLE
Remove usage of execFile

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,9 +1,15 @@
 "use strict";
 var Path = require("path"),
-    execFile = require("child_process").execFile;
+    Checker = require("jscs"),
+    ConfigFile = require("jscs/lib/cli-config"),
+    checker;
 
 module.exports = function (paths) {
-  describe("jscs", function () {
+  describe("jscs", function () {    
+    checker = new Checker();
+    checker.registerDefaultRules();
+    checker.configure(ConfigFile.load());
+    
     paths = paths || ["."];
     paths.forEach(runForPath);
   });
@@ -12,20 +18,27 @@ module.exports = function (paths) {
 function runForPath (path) {
   it("should pass for " + ("." === path ? "working directory" : path), function (done) {
     var error = new Error("");
+    error.stack = '';
 
-    execFile(
-      require.resolve("jscs/bin/jscs"),
-      [path, "--verbose"],
-      onProcessFinished
-    );
+    var promise = checker.checkDirectory(path);
 
-    function onProcessFinished (_, stdout, stderr) {
-      if (_) {
-        error.stack = stdout;
-        throw error;
+    promise.then(function(errors){
+      errors.forEach(function(err){
+        if(!err.isEmpty()){
+          err.getErrorList().forEach(function(errInstance){
+            error.stack += err.explainError(errInstance);
+            error.stack += '\n';
+          });
+        }
+      });
+      if(error.stack){
+        done(error);
       } else {
         done();
       }
-    }
+    }, function(){
+      error.message = 'jscs failed unexpectedly.';
+      done(error);
+    });
   });
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -5,11 +5,11 @@ var Path = require("path"),
     checker;
 
 module.exports = function (paths) {
-  describe("jscs", function () {    
+  describe("jscs", function () {
     checker = new Checker();
     checker.registerDefaultRules();
     checker.configure(ConfigFile.load());
-    
+
     paths = paths || ["."];
     paths.forEach(runForPath);
   });
@@ -17,27 +17,28 @@ module.exports = function (paths) {
 
 function runForPath (path) {
   it("should pass for " + ("." === path ? "working directory" : path), function (done) {
-    var error = new Error("");
-    error.stack = '';
+    var error = new Error(""),
+        promise;
+    error.stack = "";
 
-    var promise = checker.checkDirectory(path);
+    promise = checker.checkDirectory(path);
 
-    promise.then(function(errors){
-      errors.forEach(function(err){
-        if(!err.isEmpty()){
-          err.getErrorList().forEach(function(errInstance){
+    promise.then(function (errors) {
+      errors.forEach(function (err) {
+        if (!err.isEmpty()) {
+          err.getErrorList().forEach(function (errInstance) {
             error.stack += err.explainError(errInstance);
-            error.stack += '\n';
+            error.stack += "\n";
           });
         }
       });
-      if(error.stack){
+      if (error.stack) {
         done(error);
       } else {
         done();
       }
-    }, function(){
-      error.message = 'jscs failed unexpectedly.';
+    }, function () {
+      error.message = "jscs failed unexpectedly.";
       done(error);
     });
   });

--- a/package.json
+++ b/package.json
@@ -44,5 +44,8 @@
     "mocha": "^2.0.1",
     "mocha-jshint": "0.0.9",
     "tomchentw-npm-dev": "^1.1.0"
+  },
+  "dependencies": {
+    "jscs": "^1.12.0"
   }
 }


### PR DESCRIPTION
I was unable to use this module in my Windows development environment, and I determined the issue to be the use of execFile. I removed the usage of execFile and switched to programmatic usage of the JSCS module. 
