### PR TITLE
Run Checker on File as well as Directory Paths

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -17,7 +17,7 @@ module.exports = function (_paths_) {
 
 function runForPath (checker, path) {
   it("should pass for " + ("." === path ? "working directory" : path), function (done) {
-    checker.checkDirectory(path)
+    checker.checkPath(path)
       .then(formatErrors, handleRejection)
       .then(done);
 

--- a/test/index.js
+++ b/test/index.js
@@ -5,4 +5,5 @@
 describe("mocha-jscs", function() {
   require("mocha-jshint")(["./lib/"]);
   require("../lib")(["./lib/"]);
+  require("../lib")(["./lib/index.js"]);
 });


### PR DESCRIPTION
I wanted to run JSCS on a file path which threw a `Error: Error: ENOTDIR, readdir '[filepath]'` Error. Changing `checkDirectory` to `checkPath` resolves the error and gets the desired result for both a Directory and a File path.
