### PR TITLE
Increase timeout to 30 seconds, a la mocha-jshint

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -11,6 +11,8 @@ module.exports = function (_paths_) {
     checker.registerDefaultRules();
     checker.configure(ConfigFile.load());
 
+    this.timeout && this.timeout(30000);
+
     paths.forEach(runForPath.bind(null, checker));
   });
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -11,7 +11,9 @@ module.exports = function (_paths_) {
     checker.registerDefaultRules();
     checker.configure(ConfigFile.load());
 
-    this.timeout && this.timeout(30000);
+    if (this.timeout) {
+      this.timeout(30000);
+    }
 
     paths.forEach(runForPath.bind(null, checker));
   });


### PR DESCRIPTION
Title says it all. We have a fair amount of code in our path and our CI fails sporadically due to timeout. mocha-jshint had this exact line.
