### PR TITLE
publish only needed files

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,5 +42,8 @@
   },
   "dependencies": {
     "jscs": "^2.1.1"
-  }
+  },
+  "files": [
+    "lib"
+  ]
 }


### PR DESCRIPTION
Only package.json, README.md, LICENSE,CHANGELOG and lib are really needed. Specifying the "files" key in package.json will limit these files for publishing without .npmignore
https://docs.npmjs.com/files/package.json#files
currently all files are published
![image](https://cloud.githubusercontent.com/assets/933445/14456830/95cfc7f4-00af-11e6-8ba4-7e69f56f4561.png)
after publishing new version of this package with this PR it will look similar to this:
![image](https://cloud.githubusercontent.com/assets/933445/14456900/fa0b2c40-00af-11e6-8b36-96eff81dab55.png)
+Changelog
