### PR TITLE
Update jscs version

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "homepage": "https://github.com/tomchentw/mocha-jscs",
   "peerDependencies": {
-    "jscs": "^2.1.1"
+    "jscs": "^3.0.3"
   },
   "devDependencies": {
     "codeclimate-test-reporter": "^0.3.0",
@@ -41,7 +41,7 @@
     "tomchentw-npm-dev": "^3.0.0"
   },
   "dependencies": {
-    "jscs": "^2.1.1"
+    "jscs": "^3.0.3"
   },
   "files": [
     "lib"


### PR DESCRIPTION
Avoids warning about missing peer dependency when running npm install and using new versions of jscs.
